### PR TITLE
Fixed broken build on Arch Linux

### DIFF
--- a/mkfs.c
+++ b/mkfs.c
@@ -11,7 +11,9 @@
 #include "stat.h"
 #include "param.h"
 
+#ifndef static_assert
 #define static_assert(a, b) do { switch (0) case 0: case (a): ; } while (0)
+#endif
 
 #define NINODES 200
 


### PR DESCRIPTION
Using Arch Linux 4.1.4-1-ARCH and gcc version 5.2.0. I got this error on build:

```
gcc -Werror -Wall -o mkfs mkfs.c
mkfs.c:14:0: error: "static_assert" redefined [-Werror]
 #define static_assert(a, b) do { switch (0) case 0: case (a): ; } while (0)
 ^
In file included from mkfs.c:6:0:
/usr/include/assert.h:118:0: note: this is the location of the previous definition
 # define static_assert _Static_assert
 ^
cc1: all warnings being treated as errors
```

I hope this fixes it.