### PR TITLE
set tss->iomp to disable i/o in user processes

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -169,6 +169,7 @@ switchuvm(struct proc *p)
   cpu->gdt[SEG_TSS].s = 0;
   cpu->ts.ss0 = SEG_KDATA << 3;
   cpu->ts.esp0 = (uint)proc->kstack + KSTACKSIZE;
+  cpu->ts.iomb = (ushort) 0xFFFF;
   ltr(SEG_TSS << 3);
   if(p->pgdir == 0)
     panic("switchuvm: no pgdir");


### PR DESCRIPTION
I set I/O permission bit map to restrict I/O functions in user-space.