### PR TITLE
Fix memory region validation in argptr()

### DIFF
--- a/syscall.c
+++ b/syscall.c
@@ -58,7 +58,7 @@ argptr(int n, char **pp, int size)
   
   if(argint(n, &i) < 0)
     return -1;
-  if((uint)i >= proc->sz || (uint)i+size > proc->sz)
+  if(size < 0 || (uint)i >= proc->sz || (uint)i+size > proc->sz)
     return -1;
   *pp = (char*)i;
   return 0;


### PR DESCRIPTION
The `argptr()` function in `syscall.c` didn't handle negative `size` properly,
so it misunderstood negative `size` as valid.

For that reason, this code of user application will have the system write data from the file
to unallocated page, which causes page fault, which will lead to panic.

```
#include "types.h"
#include "user.h"
#include "fcntl.h"

int main(void) {
  int fd;
  fd = open("init", O_RDONLY);
  if (fd < 0) {
    printf(2, "open failed\n");
    exit();
  }
  read(fd, sbrk(0) - 1, -1);
  close(fd);
  exit();
}
```
