### PR TITLE
Fix exec-scheduler race

### DIFF
--- a/exec.c
+++ b/exec.c
@@ -95,7 +95,7 @@ exec(char *path, char **argv)
   switchuvm(proc);
   freevm(oldpgdir);
 
- yield();
+  yield();
   return 0;
 
  bad:

--- a/exec.c
+++ b/exec.c
@@ -94,6 +94,8 @@ exec(char *path, char **argv)
   proc->tf->esp = sp;
   switchuvm(proc);
   freevm(oldpgdir);
+
+ yield();
   return 0;
 
  bad:


### PR DESCRIPTION
The exec syscall continues the execution of the process without considering that it's a new process and the scheduler might want not to execute it (right now).

This patch is a fix.