### PR TITLE
Fixed broken build on newer gold linker with NaCl support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ CFLAGS = -fno-pic -static -fno-builtin -fno-strict-aliasing -fvar-tracking -fvar
 CFLAGS += $(shell $(CC) -fno-stack-protector -E -x c /dev/null >/dev/null 2>&1 && echo -fno-stack-protector)
 ASFLAGS = -m32 -gdwarf-2 -Wa,-divide
 # FreeBSD ld wants ``elf_i386_fbsd''
-LDFLAGS += -m $(shell $(LD) -V | grep elf_i386 2>/dev/null)
+LDFLAGS += -m $(shell $(LD) -V | grep elf_i386 2>/dev/null | head -n 1)
 
 xv6.img: bootblock kernel fs.img
 	dd if=/dev/zero of=xv6.img count=10000


### PR DESCRIPTION
On platforms with NaCl support, ld.gold -V will return a "elf_i386_nacl" in
addition to "elf_i386", which will make the build fail.

This modification dropped extra -m paramaters.

(Why not just use elf_i386?)