### PR TITLE
Replaced movw $0, %ax by xoring.

### DIFF
--- a/bootasm.S
+++ b/bootasm.S
@@ -57,7 +57,7 @@ start32:
   movw    %ax, %ds                # -> DS: Data Segment
   movw    %ax, %es                # -> ES: Extra Segment
   movw    %ax, %ss                # -> SS: Stack Segment
-  movw    $0, %ax                 # Zero segments not ready for use
+  xorl    %eax, %eax              # Zero segments not ready for use
   movw    %ax, %fs                # -> FS
   movw    %ax, %gs                # -> GS
 

--- a/entryother.S
+++ b/entryother.S
@@ -51,7 +51,7 @@ start32:
   movw    %ax, %ds                # -> DS: Data Segment
   movw    %ax, %es                # -> ES: Extra Segment
   movw    %ax, %ss                # -> SS: Stack Segment
-  movw    $0, %ax                 # Zero segments not ready for use
+  xorl    %eax, %eax              # Zero segments not ready for use
   movw    %ax, %fs                # -> FS
   movw    %ax, %gs                # -> GS
 


### PR DESCRIPTION
A better way to zero a register than using mov is to xor it with itself
(i.e. has shorter encoding).

So the natural way to go would to replace

movw $0, %ax

by

xorw %ax, %ax

But since we are in 32 bit mode, if we do it this way, an Operand-size
override prefix will be emitted. So we better zero the eax register (the
code does not require that the upper word of eax stays unchanged). Thus we
replace it by

xorl %eax, %eax