### PR TITLE
Replaced mov by movl

### DIFF
--- a/TRICKS
+++ b/TRICKS
@@ -11,7 +11,7 @@ forkret1 in trapasm.S is called with a tf argument.
 In order to use it, forkret1 copies the tf pointer into
 %esp and then jumps to trapret, which pops the 
 register state out of the trap frame.  If an interrupt
-came in between the mov tf, %esp and the iret that
+came in between the movl tf, %esp and the iret that
 goes back out to user space, the interrupt stack frame
 would end up scribbling over the tf and whatever memory
 lay under it.
@@ -23,7 +23,7 @@ constructed at the top of cp's kernel stack.  So tf
 *is* a valid %esp that can hold interrupt state.
 
 If other tf's were used in forkret1, we could add
-a cli before the mov tf, %esp.
+a cli before the movl tf, %esp.
 
 ---
 

--- a/entry.S
+++ b/entry.S
@@ -62,7 +62,7 @@ entry:
   # high addresses. The indirect call is needed because
   # the assembler produces a PC-relative instruction
   # for a direct jump.
-  mov $main, %eax
-  jmp *%eax
+  movl $main, %eax
+  jmp  *%eax
 
 .comm stack, KSTACKSIZE

--- a/usertests.c
+++ b/usertests.c
@@ -1550,10 +1550,10 @@ void
 validateint(int *p)
 {
   int res;
-  asm("mov %%esp, %%ebx\n\t"
-      "mov %3, %%esp\n\t"
+  asm("movl %%esp, %%ebx\n\t"
+      "movl %3, %%esp\n\t"
       "int %2\n\t"
-      "mov %%ebx, %%esp" :
+      "movl %%ebx, %%esp" :
       "=a" (res) :
       "a" (SYS_sleep), "n" (T_SYSCALL), "c" (p) :
       "ebx");


### PR DESCRIPTION
In GAS syntax movl is used (though mov is allowed if the operand size can
be inferred). To make it consistent I replaced the remaining instances of
mov by movl.
