### PR TITLE
Replaced infinite "spin"-loop by hlt

### DIFF
--- a/bootasm.S
+++ b/bootasm.S
@@ -66,14 +66,13 @@ start32:
   call    bootmain
 
   # If bootmain returns (it shouldn't), trigger a Bochs
-  # breakpoint if running under Bochs, then loop.
+  # breakpoint if running under Bochs, then halt.
   movw    $0x8a00, %ax            # 0x8a00 -> port 0x8a00
   movw    %ax, %dx
   outw    %ax, %dx
   movw    $0x8ae0, %ax            # 0x8ae0 -> port 0x8a00
   outw    %ax, %dx
-spin:
-  jmp     spin
+  hlt
 
 # Bootstrap GDT
 .p2align 2                                # force 4 byte alignment

--- a/entryother.S
+++ b/entryother.S
@@ -77,8 +77,7 @@ start32:
   outw    %ax, %dx
   movw    $0x8ae0, %ax
   outw    %ax, %dx
-spin:
-  jmp     spin
+  hlt
 
 .p2align 2
 gdt:


### PR DESCRIPTION
In bootasm.S and entryother.S if the code returns (it shouldn't as
remarked in bootasm.S) the code goes to an infinite "spin" loop. But doing
nothing (except perhaps waiting for an interrupt) in system mode is what the hlt
instruction is for. So I replaced this infinite loop by a hlt.