### PR TITLE
Fix deadlock between fork() and icache.

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -156,12 +156,22 @@ fork(void)
   // Clear %eax so that fork returns 0 in the child.
   np->tf->eax = 0;
 
+  safestrcpy(np->name, proc->name, sizeof(proc->name));
+  release(&ptable.lock);
+
+  // It is safe to release ptable.lock here and yet reference both
+  // np-> and proc-> objects because np-> is in state EMBRYO and
+  // therefore not moving until we say so, and proc-> is us, so,
+  // again, not doing anything with its ofile[]s or its cwd until
+  // we let it.
   for(i = 0; i < NOFILE; i++)
     if(proc->ofile[i])
       np->ofile[i] = filedup(proc->ofile[i]);
   np->cwd = idup(proc->cwd);
 
-  safestrcpy(np->name, proc->name, sizeof(proc->name));
+  // This acquire-set-release dance forces the compiler and the CPU
+  // to do and publish all of the above changes before this write
+  acquire(&ptable.lock);
 
   pid = np->pid;
 


### PR DESCRIPTION
This was caused by 19f65413bdf7553036f2c388552580905730060a's move to holding ptable.lock across the entirety of process creation; we need to drop it for the complex call chains inside the filesystem.

```
  (gdb) info threads
    Id   Target Id         Frame 
  * 1    Thread 1 (CPU#0 [running]) acquire (lk=0x80111a00 <icache>) at spinlock.c:32
    2    Thread 2 (CPU#1 [running]) acquire (lk=0x80113120 <ptable>) at spinlock.c:32
  (gdb) bt
  #0  acquire (lk=0x80111a00 <icache>) at spinlock.c:32
  #1  0x80101c14 in idup (ip=0x80111a34 <icache+52>) at fs.c:262
  #2  0x80104042 in fork () at proc.c:161
  #3  0x80104db9 in syscall () at syscall.c:132
  #4  0x80105dd9 in trap (tf=0x8dfbefb4) at trap.c:49
  #5  0x80105bcb in alltraps () at trapasm.S:23
  #6  0x8dfbefb4 in ?? ()
  Backtrace stopped: previous frame inner to this frame (corrupt stack?)
  (gdb) thread 2
  [Switching to thread 2 (Thread 2)]
  #0  acquire (lk=0x80113120 <ptable>) at spinlock.c:32
  32	  while(xchg(&lk->locked, 1) != 0)
  (gdb) bt
  #0  acquire (lk=0x80113120 <ptable>) at spinlock.c:32
  #1  0x80104574 in wakeup (chan=0x80111a34 <icache+52>) at proc.c:413
  #2  0x80101d74 in iunlock (ip=0x80111a34 <icache+52>) at fs.c:310
  #3  0x801023dd in namex (path=<optimized out>, nameiparent=1, name=0x8dfbcf12 "p0") at fs.c:627
  #4  0x80104e1f in create (path=<optimized out>, type=type@entry=2, major=major@entry=0, minor=0) at sysfile.c:245
  #5  0x80105614 in sys_open () at sysfile.c:297
  #6  0x80104db9 in syscall () at syscall.c:132
  #7  0x80105dd9 in trap (tf=0x8dfbcfb4) at trap.c:49
  #8  0x80105bcb in alltraps () at trapasm.S:23
  #9  0x8dfbcfb4 in ?? ()
  Backtrace stopped: previous frame inner to this frame (corrupt stack?)
```