### PR TITLE
Add support for qemu-system-x86_64 in 64bit hosts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,8 @@ QEMU = $(shell if which qemu > /dev/null; \
 	then echo qemu; exit; \
 	elif which qemu-system-i386 > /dev/null; \
 	then echo qemu-system-i386; exit; \
+	elif which qemu-system-x86_64 > /dev/null; \
+	then echo qemu-system-x86_64; exit; \
 	else \
 	qemu=/Applications/Q.app/Contents/MacOS/i386-softmmu.app/Contents/MacOS/i386-softmmu; \
 	if test -x $$qemu; then echo $$qemu; exit; fi; fi; \


### PR DESCRIPTION
As x86-64 is a superset of x86, we can use qemu-system-x86_64 to run the OS image.