### PR TITLE
Update defs.h - correct alignment of releasesleep

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -131,7 +131,7 @@ void            popcli(void);
 
 // sleeplock.c
 void            acquiresleep(struct sleeplock*);
-void             releasesleep(struct sleeplock*);
+void            releasesleep(struct sleeplock*);
 int             holdingsleep(struct sleeplock*);
 void            initsleeplock(struct sleeplock*, char*);
 


### PR DESCRIPTION
Correct alignment of releasesleep declaration (which is defined in sleeplock.c).