### PR TITLE
Free pgdir in setupkvm in case of mappages failure

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -137,8 +137,10 @@ setupkvm(void)
     panic("PHYSTOP too high");
   for(k = kmap; k < &kmap[NELEM(kmap)]; k++)
     if(mappages(pgdir, k->virt, k->phys_end - k->phys_start,
-                (uint)k->phys_start, k->perm) < 0)
+                (uint)k->phys_start, k->perm) < 0) {
+      freevm(pgdir);
       return 0;
+    }
   return pgdir;
 }
 


### PR DESCRIPTION
There is a potential memory leak when mappages() fails inside setupkvm().
A call to freevm() is added in this case so as to reclaim the lost mapping pages.