### PR TITLE
Disable PIE when possible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,14 @@ ASFLAGS = -m32 -gdwarf-2 -Wa,-divide
 # FreeBSD ld wants ``elf_i386_fbsd''
 LDFLAGS += -m $(shell $(LD) -V | grep elf_i386 2>/dev/null | head -n 1)
 
+# Disable PIE when possible
+ifneq ($(shell $(CC) -dumpspecs 2>/dev/null | grep -e '[^f]no-pie'),)
+CFLAGS += -fno-pie -no-pie
+endif
+ifneq ($(shell $(CC) -dumpspecs 2>/dev/null | grep -e '[^f]nopie'),)
+CFLAGS += -fno-pie -nopie
+endif
+
 xv6.img: bootblock kernel fs.img
 	dd if=/dev/zero of=xv6.img count=10000
 	dd if=bootblock of=xv6.img conv=notrunc


### PR DESCRIPTION
The Ubuntu 16.10 toolchain enables the PIE (position independent executable) option by default.  This is not suitable or appropriate for the xv6 kernel.

The purpose of this patch is to disable PIE when possible, by appending toolchain-appropriate arguments to CFLAGS and LDFLAGS.