### PR TITLE
Fix "make dist" by adding missing files to runoff.list

### DIFF
--- a/runoff.list
+++ b/runoff.list
@@ -7,6 +7,7 @@ x86.h
 asm.h
 mmu.h
 elf.h
+date.h
 
 # entering xv6
 entry.S
@@ -77,3 +78,5 @@ sh.c
 bootasm.S
 bootmain.c
 
+# link
+kernel.ld


### PR DESCRIPTION
In addition to driving documentation, runoff.list is used as a specification for the files that comprise an xv6 distribution.

Add date.h and kernel.ld to runoff.list, so that dist subdirectory created by "make dist" is complete and buildable.