### PR TITLE
Fix typo in dirlookup

### DIFF
--- a/fs.c
+++ b/fs.c
@@ -518,7 +518,7 @@ dirlookup(struct inode *dp, char *name, uint *poff)
 
   for(off = 0; off < dp->size; off += sizeof(de)){
     if(readi(dp, (char*)&de, off, sizeof(de)) != sizeof(de))
-      panic("dirlink read");
+      panic("dirlookup read");
     if(de.inum == 0)
       continue;
     if(namecmp(name, de.name) == 0){


### PR DESCRIPTION
![hooray](https://media.giphy.com/media/MqxZxTlvcY5BS/giphy.gif)

(update 4/27) fs.c:dirlookup checks the return value of `readi`, and if it's invalid it panics with `"dirlink read"` instead of `"dirlookup read"`. Perhaps a copy-paste error.