### PR TITLE
Fixed void pointer arithmetic and wrong function pointer cast.

### DIFF
--- a/main.c
+++ b/main.c
@@ -83,7 +83,7 @@ startothers(void)
     // is running in low  memory, so we use entrypgdir for the APs too.
     stack = kalloc();
     *(void**)(code-4) = stack + KSTACKSIZE;
-    *(void**)(code-8) = mpenter;
+    *(void(**)(void))(code-8) = mpenter;
     *(int**)(code-12) = (void *) V2P(entrypgdir);
 
     lapicstartap(c->apicid, V2P(code));

--- a/memlayout.h
+++ b/memlayout.h
@@ -9,7 +9,7 @@
 #define KERNLINK (KERNBASE+EXTMEM)  // Address where kernel is linked
 
 #define V2P(a) (((uint) (a)) - KERNBASE)
-#define P2V(a) (((void *) (a)) + KERNBASE)
+#define P2V(a) ((void *)(((char *) (a)) + KERNBASE))
 
 #define V2P_WO(x) ((x) - KERNBASE)    // same as V2P, but without casts
 #define P2V_WO(x) ((x) + KERNBASE)    // same as P2V, but without casts


### PR DESCRIPTION
1. The `P2V` macro present in `memlayout.h` uses a non-standard GNU extension of `void` pointer arithmetic,
this PR transparently presents the correct C standard way of achieving the same result using a `char` pointer.

2. The cast found in `main.c` in the `startothers` function wrongly assigns a function pointer to a void pointer object again in a non-standard way, the cast was replaced to have the assignment made to a function pointer object.