### PR TITLE
freeing allocated page on failure in copyuvm

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -333,7 +333,10 @@ copyuvm(pde_t *pgdir, uint sz)
       goto bad;
     memmove(mem, (char*)P2V(pa), PGSIZE);
     if(mappages(d, (void*)i, PGSIZE, V2P(mem), flags) < 0)
-      goto bad;
+	{
+		kfree(mem);
+		goto bad;
+	}
   }
   return d;
 


### PR DESCRIPTION
The new page allocated (mem) should be freed once mappages fails.