### PR TITLE
Avoid busy loop at no running proc

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -324,18 +324,27 @@ scheduler(void)
 {
   struct proc *p;
   struct cpu *c = mycpu();
+  int norunner;
   c->proc = 0;
   
+  norunner = 0;
   for(;;){
     // Enable interrupts on this processor.
     sti();
 
+    if(norunner){
+      // No proc to run: Halt until something happens.
+      hlt();
+    }
+
     // Loop over process table looking for process to run.
     acquire(&ptable.lock);
+    norunner = 1;
     for(p = ptable.proc; p < &ptable.proc[NPROC]; p++){
       if(p->state != RUNNABLE)
         continue;
 
+      norunner = 0;
       // Switch to chosen process.  It is the process's job
       // to release ptable.lock and then reacquire it
       // before jumping back to us.

--- a/x86.h
+++ b/x86.h
@@ -144,6 +144,12 @@ lcr3(uint val)
   asm volatile("movl %0,%%cr3" : : "r" (val));
 }
 
+static inline void
+hlt(void)
+{
+  asm volatile("hlt");
+}
+
 //PAGEBREAK: 36
 // Layout of the trap frame built on the stack by the
 // hardware and by trapasm.S, and passed to trap().


### PR DESCRIPTION
When I run XV6 on QEMU,
it takes 100% CPU time on its shell.

I suspect that XV6 never sleep.

When `read` function is called from shell,
there is no running proc until any interruption occurred.

In `scheduler` function, if no running proc exists,
I think it becomes busy loop.

This change makes CPU halts when there is no running proc.
