### PR TITLE
Use one byte less in boot loader

### DIFF
--- a/bootasm.S
+++ b/bootasm.S
@@ -57,7 +57,7 @@ start32:
   movw    %ax, %ds                # -> DS: Data Segment
   movw    %ax, %es                # -> ES: Extra Segment
   movw    %ax, %ss                # -> SS: Stack Segment
-  movw    $0, %ax                 # Zero segments not ready for use
+  xor     %ax, %ax                # Zero segments not ready for use
   movw    %ax, %fs                # -> FS
   movw    %ax, %gs                # -> GS
 


### PR DESCRIPTION
Using xor %ax, %ax from movw 0, %ax saves one byte.