### PR TITLE
Pass current offset to drivers.

### DIFF
--- a/console.c
+++ b/console.c
@@ -233,7 +233,7 @@ consoleintr(int (*getc)(void))
 }
 
 int
-consoleread(struct inode *ip, char *dst, int n)
+consoleread(struct inode *ip, char *dst, uint off, int n)
 {
   uint target;
   int c;
@@ -271,7 +271,7 @@ consoleread(struct inode *ip, char *dst, int n)
 }
 
 int
-consolewrite(struct inode *ip, char *buf, int n)
+consolewrite(struct inode *ip, char *buf, uint off, int n)
 {
   int i;
 

--- a/file.h
+++ b/file.h
@@ -28,8 +28,8 @@ struct inode {
 // table mapping major device number to
 // device functions
 struct devsw {
-  int (*read)(struct inode*, char*, int);
-  int (*write)(struct inode*, char*, int);
+  int (*read)(struct inode*, char*, uint, int);
+  int (*write)(struct inode*, char*, uint, int);
 };
 
 extern struct devsw devsw[];

--- a/fs.c
+++ b/fs.c
@@ -459,7 +459,7 @@ readi(struct inode *ip, char *dst, uint off, uint n)
   if(ip->type == T_DEV){
     if(ip->major < 0 || ip->major >= NDEV || !devsw[ip->major].read)
       return -1;
-    return devsw[ip->major].read(ip, dst, n);
+    return devsw[ip->major].read(ip, dst, off, n);
   }
 
   if(off > ip->size || off + n < off)
@@ -488,7 +488,7 @@ writei(struct inode *ip, char *src, uint off, uint n)
   if(ip->type == T_DEV){
     if(ip->major < 0 || ip->major >= NDEV || !devsw[ip->major].write)
       return -1;
-    return devsw[ip->major].write(ip, src, n);
+    return devsw[ip->major].write(ip, src, off, n);
   }
 
   if(off > ip->size || off + n < off)


### PR DESCRIPTION
Passing current offset into file is needed for drivers to handle random access devices (such as /dev/kmem).

This can be used in a lab, assuming students have implemented the lseek syscall first.