### PR TITLE
Fixes for xv6.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,7 @@ CFLAGS += $(shell $(CC) -fno-stack-protector -E -x c /dev/null >/dev/null 2>&1 &
 ASFLAGS = -m32 -gdwarf-2 -Wa,-divide
 # FreeBSD ld wants ``elf_i386_fbsd''
 LDFLAGS += -m $(shell $(LD) -V | grep elf_i386 2>/dev/null | head -n 1)
+HOSTCC = gcc
 
 # Disable PIE when possible (for Ubuntu 16.10 toolchain)
 ifneq ($(shell $(CC) -dumpspecs 2>/dev/null | grep -e '[^f]no-pie'),)
@@ -157,7 +158,7 @@ _forktest: forktest.o $(ULIB)
 	$(OBJDUMP) -S _forktest > forktest.asm
 
 mkfs: mkfs.c fs.h
-	gcc -Werror -Wall -o mkfs mkfs.c
+	$(HOSTCC) -Werror -Wall -o mkfs mkfs.c
 
 # Prevent deletion of intermediate files, e.g. cat.o, after first build, so
 # that disk image changes after first build are persistent until clean.  More

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ endif
 CC = $(TOOLPREFIX)gcc
 AS = $(TOOLPREFIX)gas
 LD = $(TOOLPREFIX)ld
+STRIP = $(TOOLPREFIX)strip
 OBJCOPY = $(TOOLPREFIX)objcopy
 OBJDUMP = $(TOOLPREFIX)objdump
 CFLAGS = -fno-pic -static -fno-builtin -fno-strict-aliasing -O2 -Wall -MD -ggdb -m32 -Werror -fno-omit-frame-pointer
@@ -184,6 +185,7 @@ UPROGS=\
 	_zombie\
 
 fs.img: mkfs README $(UPROGS)
+	$(STRIP) _usertests
 	./mkfs fs.img README $(UPROGS)
 
 -include *.d

--- a/cuth
+++ b/cuth
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 $| = 1;
 

--- a/fs.c
+++ b/fs.c
@@ -84,7 +84,6 @@ bfree(int dev, uint b)
   struct buf *bp;
   int bi, m;
 
-  readsb(dev, &sb);
   bp = bread(dev, BBLOCK(b, sb));
   bi = b % BPB;
   m = 1 << (bi % 8);

--- a/pr.pl
+++ b/pr.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use POSIX qw(strftime);
 

--- a/proc.c
+++ b/proc.c
@@ -142,7 +142,10 @@ userinit(void)
   p->tf->eip = 0;  // beginning of initcode.S
 
   safestrcpy(p->name, "initcode", sizeof(p->name));
-  p->cwd = namei("/");
+
+  // Note that we assign p->cwd in forkret, when
+  // returning to userspace after initializing the
+  // inode cache.
 
   // this assignment to p->state lets other cores
   // run this process. the acquire forces the above
@@ -415,6 +418,7 @@ forkret(void)
     first = 0;
     iinit(ROOTDEV);
     initlog(ROOTDEV);
+    myproc()->cwd = namei("/");
   }
 
   // Return to "caller", actually trapret (see allocproc).

--- a/proc.c
+++ b/proc.c
@@ -93,7 +93,9 @@ found:
 
   // Allocate kernel stack.
   if((p->kstack = kalloc()) == 0){
+    acquire(&ptable.lock);
     p->state = UNUSED;
+    release(&ptable.lock);
     return 0;
   }
   sp = p->kstack + KSTACKSIZE;
@@ -193,7 +195,9 @@ fork(void)
   if((np->pgdir = copyuvm(curproc->pgdir, curproc->sz)) == 0){
     kfree(np->kstack);
     np->kstack = 0;
+    acquire(&ptable.lock);
     np->state = UNUSED;
+    release(&ptable.lock);
     return -1;
   }
   np->sz = curproc->sz;

--- a/proc.c
+++ b/proc.c
@@ -279,6 +279,8 @@ wait(void)
   struct proc *p;
   int havekids, pid;
   struct proc *curproc = myproc();
+  pde_t *zpgdir;
+  char *zkstack;
   
   acquire(&ptable.lock);
   for(;;){
@@ -291,15 +293,17 @@ wait(void)
       if(p->state == ZOMBIE){
         // Found one.
         pid = p->pid;
-        kfree(p->kstack);
+        zkstack = p->kstack;
         p->kstack = 0;
-        freevm(p->pgdir);
+        zpgdir = p->pgdir;
         p->pid = 0;
         p->parent = 0;
         p->name[0] = 0;
         p->killed = 0;
         p->state = UNUSED;
         release(&ptable.lock);
+        kfree(zkstack);
+        freevm(zpgdir);
         return pid;
       }
     }

--- a/runoff1
+++ b/runoff1
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 $n = 0;
 $v = 0;

--- a/sign.pl
+++ b/sign.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 open(SIG, $ARGV[0]) || die "open $ARGV[0]: $!";
 

--- a/sysfile.c
+++ b/sysfile.c
@@ -241,7 +241,6 @@ bad:
 static struct inode*
 create(char *path, short type, short major, short minor)
 {
-  uint off;
   struct inode *ip, *dp;
   char name[DIRSIZ];
 
@@ -249,7 +248,7 @@ create(char *path, short type, short major, short minor)
     return 0;
   ilock(dp);
 
-  if((ip = dirlookup(dp, name, &off)) != 0){
+  if((ip = dirlookup(dp, name, 0)) != 0){
     iunlockput(dp);
     ilock(ip);
     if(type == T_FILE && ip->type == T_FILE)

--- a/vectors.pl
+++ b/vectors.pl
@@ -1,4 +1,6 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
+
+use warnings;
 
 # Generate vectors.S, the trap/interrupt entry points.
 # There has to be one entry point per interrupt number


### PR DESCRIPTION
A few fixes for xv6. These are mostly infrastructure changes to paper over differences between environments, but also fixing an assertion failure in `mkfs` and a couple of small things in the kernel itself.

Please note that, about 10 years ago, someone created a git _tag_ called `master`; presumably this was an accident. This causes ambiguity when performing e.g., a rebase; `git checkout master` will check out the master branch as expected, but `git rebase master` (or even origin/master!) will rebase against the *tag*, which is most definitely not desired.

The `master` tag should probably be deleted, though I don't know how to do that using a github pull request; a repository owner can do it, however.