### PR TITLE
Fix Makefile comments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,9 +150,9 @@ _%: %.o $(ULIB)
 	$(OBJDUMP) -S $@ > $*.asm
 	$(OBJDUMP) -t $@ | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > $*.sym
 
+# forktest has less library code linked in - needs to be small
+# in order to be able to max out the proc table.
 _forktest: forktest.o $(ULIB)
-	# forktest has less library code linked in - needs to be small
-	# in order to be able to max out the proc table.
 	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o _forktest forktest.o ulib.o usys.o
 	$(OBJDUMP) -S _forktest > forktest.asm
 


### PR DESCRIPTION
According to the GNU Make documentation ([5.1 Recipe Syntax](https://www.gnu.org/software/make/manual/html_node/Recipe-Syntax.html#Recipe-Syntax)):

> Any line in the makefile that begins with a tab and appears in a “rule context” (that is, after a rule has been started until another rule or variable definition) will be considered part of a recipe for that rule.

> A comment in a recipe is not a make comment; it will be passed to the shell as-is. Whether the shell treats it as a comment or not depends on your shell.

So I think we should change the _**shell comments**_ in Makefile to _**make comments**_.



