### PR TITLE
Suppress error messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,11 +55,11 @@ endif
 
 # Try to infer the correct QEMU
 ifndef QEMU
-QEMU = $(shell if which qemu > /dev/null; \
+QEMU = $(shell if which qemu > /dev/null 2>&1; \
 	then echo qemu; exit; \
-	elif which qemu-system-i386 > /dev/null; \
+	elif which qemu-system-i386 > /dev/null 2>&1; \
 	then echo qemu-system-i386; exit; \
-	elif which qemu-system-x86_64 > /dev/null; \
+	elif which qemu-system-x86_64 > /dev/null 2>&1; \
 	then echo qemu-system-x86_64; exit; \
 	else \
 	qemu=/Applications/Q.app/Contents/MacOS/i386-softmmu.app/Contents/MacOS/i386-softmmu; \


### PR DESCRIPTION
When I ran `make qemu`, I got something like this:

> ...
which: no qemu in (/usr/local/sbin:/usr/local/bin...)
which: no qemu-system-i386 in (/usr/local/sbin:/usr/local/bin...)
...

The error messages of the **_which qemu_** command should not be printed.