### PR TITLE
fix KEY_HOME scan code

### DIFF
--- a/kbd.h
+++ b/kbd.h
@@ -66,7 +66,7 @@ static uchar normalmap[256] =
   [0xC8] KEY_UP,    [0xD0] KEY_DN,
   [0xC9] KEY_PGUP,  [0xD1] KEY_PGDN,
   [0xCB] KEY_LF,    [0xCD] KEY_RT,
-  [0x97] KEY_HOME,  [0xCF] KEY_END,
+  [0xC7] KEY_HOME,  [0xCF] KEY_END,
   [0xD2] KEY_INS,   [0xD3] KEY_DEL
 };
 
@@ -88,7 +88,7 @@ static uchar shiftmap[256] =
   [0xC8] KEY_UP,    [0xD0] KEY_DN,
   [0xC9] KEY_PGUP,  [0xD1] KEY_PGDN,
   [0xCB] KEY_LF,    [0xCD] KEY_RT,
-  [0x97] KEY_HOME,  [0xCF] KEY_END,
+  [0xC7] KEY_HOME,  [0xCF] KEY_END,
   [0xD2] KEY_INS,   [0xD3] KEY_DEL
 };
 
@@ -106,7 +106,7 @@ static uchar ctlmap[256] =
   [0xC8] KEY_UP,    [0xD0] KEY_DN,
   [0xC9] KEY_PGUP,  [0xD1] KEY_PGDN,
   [0xCB] KEY_LF,    [0xCD] KEY_RT,
-  [0x97] KEY_HOME,  [0xCF] KEY_END,
+  [0xC7] KEY_HOME,  [0xCF] KEY_END,
   [0xD2] KEY_INS,   [0xD3] KEY_DEL
 };
 


### PR DESCRIPTION
Fix the `KEY_HOME` scan code. Currently incorrect. Reference list of scancodes: https://wiki.osdev.org/PS/2_Keyboard#Scan_Code_Sets