### PR TITLE
Remove BYTE directives from kernel linker script to fix triple fault on boot

### DIFF
--- a/kernel.ld
+++ b/kernel.ld
@@ -26,16 +26,12 @@ SECTIONS
 		PROVIDE(__STAB_BEGIN__ = .);
 		*(.stab);
 		PROVIDE(__STAB_END__ = .);
-		BYTE(0)		/* Force the linker to allocate space
-				   for this section */
 	}
 
 	.stabstr : {
 		PROVIDE(__STABSTR_BEGIN__ = .);
 		*(.stabstr);
 		PROVIDE(__STABSTR_END__ = .);
-		BYTE(0)		/* Force the linker to allocate space
-				   for this section */
 	}
 
 	/* Adjust the address for the data segment to the next page */


### PR DESCRIPTION
When compiling with binutils version >=2.33, xv6 will triple fault on boot. Although this may be a regression in binutils, this PR will prevent the triple fault.

For binutils >=2.33, the BYTE directives produce an incorrect physical address for the second LOAD memory segment in the ELF header of `kernel`. This can be observed with `objdump -x kernel` after compiling. I'm not sure why this happens; there may be other ways to fix the problem.

This bug was noticed because this version of xv6 is used for a course at the University of Virginia.