### PR TITLE
fix .gdbinit.tmpl

### DIFF
--- a/.gdbinit.tmpl
+++ b/.gdbinit.tmpl
@@ -3,14 +3,14 @@ set $lastcs = -1
 define hook-stop
   # There doesn't seem to be a good way to detect if we're in 16- or
   # 32-bit mode, but in 32-bit mode we always run with CS == 8 in the
-  # kernel and CS == 35 in user space
-  if $cs == 8 || $cs == 35
-    if $lastcs != 8 && $lastcs != 35
+  # kernel and CS == 27 in user space
+  if $cs == 8 || $cs == 27
+    if $lastcs != 8 && $lastcs != 27
       set architecture i386
     end
     x/i $pc
   else
-    if $lastcs == -1 || $lastcs == 8 || $lastcs == 35
+    if $lastcs == -1 || $lastcs == 8 || $lastcs == 27
       set architecture i8086
     end
     # Translate the segment:offset into a physical address


### PR DESCRIPTION
https://github.com/mit-pdos/xv6-public/blob/34f060c3dcf3bf3dde683df9ff9872bc9f1d5d14/mmu.h#L14-L19
https://github.com/mit-pdos/xv6-public/blob/34f060c3dcf3bf3dde683df9ff9872bc9f1d5d14/mmu.h#L53
https://github.com/mit-pdos/xv6-public/blob/34f060c3dcf3bf3dde683df9ff9872bc9f1d5d14/proc.c#L134
in the xv6 user space, the  CS register is `(SEG_UCODE << 3) | DPL_USER`, it's 27 instead of 35.