### PR TITLE
Added CPU pausing

### DIFF
--- a/spinlock.c
+++ b/spinlock.c
@@ -29,8 +29,8 @@ acquire(struct spinlock *lk)
     panic("acquire");
 
   // The xchg is atomic.
-  while(xchg(&lk->locked, 1) != 0) pause();
-    ;
+  while(xchg(&lk->locked, 1) != 0)
+    pause();
 
   // Tell the C compiler and the processor to not move loads or stores
   // past this point, to ensure that the critical section's memory

--- a/spinlock.c
+++ b/spinlock.c
@@ -29,7 +29,7 @@ acquire(struct spinlock *lk)
     panic("acquire");
 
   // The xchg is atomic.
-  while(xchg(&lk->locked, 1) != 0)
+  while(xchg(&lk->locked, 1) != 0) pause();
     ;
 
   // Tell the C compiler and the processor to not move loads or stores

--- a/x86.h
+++ b/x86.h
@@ -117,6 +117,12 @@ sti(void)
   asm volatile("sti");
 }
 
+static inline void
+pause(void)
+{
+  asm volatile("pause");
+}
+
 static inline uint
 xchg(volatile uint *addr, uint newval)
 {


### PR DESCRIPTION
I've added a `pause` statement in the spinlock's spinning loop. This will de-pipeline the memory needs and waste less energy.