### PR TITLE
Remove setproc

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -114,7 +114,6 @@ void            pinit(void);
 void            procdump(void);
 void            scheduler(void) __attribute__((noreturn));
 void            sched(void);
-void            setproc(struct proc*);
 void            sleep(void*, struct spinlock*);
 void            userinit(void);
 int             wait(void);


### PR DESCRIPTION
`setproc` is just a prototype, and isn't defined or used anywhere else.