### PR TITLE
use longform for -smp switch to Qemu, needed for Qemu 6.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,7 @@ QEMUGDB = $(shell if $(QEMU) -help | grep -q '^-gdb'; \
 ifndef CPUS
 CPUS := 2
 endif
-QEMUOPTS = -drive file=fs.img,index=1,media=disk,format=raw -drive file=xv6.img,index=0,media=disk,format=raw -smp $(CPUS) -m 512 $(QEMUEXTRA)
+QEMUOPTS = -drive file=fs.img,index=1,media=disk,format=raw -drive file=xv6.img,index=0,media=disk,format=raw -smp cpus=$(CPUS),cores=1,threads=1,sockets=$(CPUS) -m 512 $(QEMUEXTRA)
 
 qemu: fs.img xv6.img
 	$(QEMU) -serial mon:stdio $(QEMUOPTS)


### PR DESCRIPTION
as discussed in https://lists.nongnu.org/archive/html/qemu-discuss/2022-01/msg00036.html, this makes xv6 work on Qemu 6.2.0.