### PR TITLE
fix balloc count

### DIFF
--- a/mkfs.c
+++ b/mkfs.c
@@ -162,7 +162,7 @@ main(int argc, char *argv[])
   din.size = xint(off);
   winode(rootino, &din);
 
-  balloc(freeblock);
+  balloc(freeblock-1);
 
   exit(0);
 }


### PR DESCRIPTION
When I was doing the OSTEP project [File System Checking](https://github.com/remzi-arpacidusseau/ostep-projects/blob/master/filesystems-checker/README.md#file-system-checking) with [ostep-hw](https://github.com/czg-sci-42ver/ostep-hw/tree/master/projects/filesystems-check) repo help, I find one small problem.

Due to `freeblock` is incremented after the assignment by `indirect[fbn - NDIRECT] = xint(freeblock++);` in `iappend`, it will point to one **unused** block at the last `iappend`

IMHO, `balloc(freeblock-1);` is more reasonable although only one small tweak. Hope that I didn't say something wrong.