### PR TITLE
Fix for Modern Linux 2025 - GCC 15, Binutils 2.45 (Arch btw)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ OBJS = \
 # TOOLPREFIX = i386-jos-elf
 
 # Using native tools (e.g., on X86 Linux)
-#TOOLPREFIX = 
+TOOLPREFIX =
 
 # Try to infer the correct TOOLPREFIX if not set
 ifndef TOOLPREFIX
@@ -76,7 +76,8 @@ AS = $(TOOLPREFIX)gas
 LD = $(TOOLPREFIX)ld
 OBJCOPY = $(TOOLPREFIX)objcopy
 OBJDUMP = $(TOOLPREFIX)objdump
-CFLAGS = -fno-pic -static -fno-builtin -fno-strict-aliasing -O2 -Wall -MD -ggdb -m32 -Werror -fno-omit-frame-pointer
+CFLAGS = -fno-pic -static -fno-builtin -fno-strict-aliasing -O2 -Wall -MD -ggdb -m32 -fno-omit-frame-pointer
+CFLAGS += -mno-sse
 CFLAGS += $(shell $(CC) -fno-stack-protector -E -x c /dev/null >/dev/null 2>&1 && echo -fno-stack-protector)
 ASFLAGS = -m32 -gdwarf-2 -Wa,-divide
 # FreeBSD ld wants ``elf_i386_fbsd''
@@ -116,6 +117,7 @@ entryother: entryother.S
 
 initcode: initcode.S
 	$(CC) $(CFLAGS) -nostdinc -I. -c initcode.S
+	$(OBJCOPY) --remove-section .note.gnu.property initcode.o
 	$(LD) $(LDFLAGS) -N -e start -Ttext 0 -o initcode.out initcode.o
 	$(OBJCOPY) -S -O binary initcode.out initcode
 	$(OBJDUMP) -S initcode.o > initcode.asm
@@ -145,8 +147,14 @@ vectors.S: vectors.pl
 
 ULIB = ulib.o usys.o printf.o umalloc.o
 
+# Link user progs via CC so -no-pie reaches the linker
 _%: %.o $(ULIB)
-	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o $@ $^
+	$(CC) $(CFLAGS) -nostdlib -static \
+	    -Wl,-N,-Ttext,0,-e,main,--omagic,--build-id=none \
+	    -o $@ $^
+	# Strip modern note sections that can trigger extra LOADs
+	-$(OBJCOPY) --remove-section .note.gnu.property \
+	            --remove-section .note.gnu.build-id $@
 	$(OBJDUMP) -S $@ > $*.asm
 	$(OBJDUMP) -t $@ | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > $*.sym
 
@@ -195,7 +203,7 @@ clean:
 	$(UPROGS)
 
 # make a printout
-FILES = $(shell grep -v '^\#' runoff.list)
+FILES = $(shell grep -v '^#' runoff.list)
 PRINT = runoff.list runoff.spec README toc.hdr toc.ftr $(FILES)
 
 xv6.pdf: $(PRINT)


### PR DESCRIPTION
This patch fixes build and runtime issues when compiling xv6 on modern Linux distributions (e.g. Arch, Fedora, Ubuntu ≥24).
It ensures compatibility with updated toolchains and linkers that default to PIE and add ELF metadata sections incompatible with xv6’s minimalist loader.

This makes xv6 build and run cleanly in native, modern Linux environments — especially useful for **students working on OS coursework or xv6-based assignments**. :+1: 


## After the fix, it works
<img width="1650" height="1291" alt="image" src="https://github.com/user-attachments/assets/4aebd05c-dfeb-4d62-87f6-e79bfa533a83" />

## Changes made

```diff
+# Link user progs via CC so -no-pie reaches the linker
 _%: %.o $(ULIB)
-	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o $@ $^
+	$(CC) $(CFLAGS) -nostdlib -static \
+	    -Wl,-N,-Ttext,0,-e,main,--omagic,--build-id=none \
+	    -o $@ $^
+	# Strip modern note sections that can trigger extra LOADs
+	-$(OBJCOPY) --remove-section .note.gnu.property \
+	            --remove-section .note.gnu.build-id $@

```
and others.

### Explanation

The original build used ld directly, so modern toolchains on Arch added extra ELF metadata and an extra PT_LOAD segment that xv6’s simple exec couldn’t handle.
By linking with $(CC) instead, the -no-pie and old-style layout flags reached the linker, forcing a single flat segment starting at address 0.
Stripping modern .note.gnu.* sections removed remaining metadata that caused extra segments, restoring the classic ELF format xv6 expects.

## My Personal Dev Environment
```
gcc (GCC) 15.2.1 20250813
```
```
 nu ❯ uname
╭──────────────────┬────────────────────────────────────────────────────────╮
│ kernel-name      │ Linux                                                  │
│ nodename         │ iusearchbtw                                            │
│ kernel-release   │ 6.17.1-arch1-1                                         │
│ kernel-version   │ #1 SMP PREEMPT_DYNAMIC Mon, 06 Oct 2025 18:48:29 +0000 │
│ machine          │ x86_64                                                 │
│ operating-system │ GNU/Linux                                              │
╰──────────────────┴────────────────────────────────────────────────────────╯
```
```
GNU ld (GNU Binutils) 2.45.0
Copyright (C) 2025 Free Software Foundation, Inc.
This program is free software; you may redistribute it under the terms of
the GNU General Public License version 3 or (at your option) a later version.
This program has absolutely no warranty.
```


BTW, I use arch.