### PR TITLE
This repo is unmaintained !!!

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,8 @@
+This repo is unmaintained !!!
+If you want to use xv6 for the **x86** architecture, you must switch to Xv6-64:
+- https://xv6-64.gitlab.io/xv6-64/
+- https://gitlab.com/xv6-64
+
 NOTE: we have stopped maintaining the x86 version of xv6, and switched
 our efforts to the RISC-V version
 (https://github.com/mit-pdos/xv6-riscv.git)


### PR DESCRIPTION
If you want to use xv6 for the **x86** architecture, you must switch to Xv6-64:
- https://xv6-64.gitlab.io/xv6-64/
- https://gitlab.com/xv6-64